### PR TITLE
Advanced encoded queries

### DIFF
--- a/servicenow_rest/api.py
+++ b/servicenow_rest/api.py
@@ -33,7 +33,6 @@ class Client(object):
 
         ## Request properties
         self.table = None
-        self.sysid = None
 
     def _create_session(self):
         """

--- a/servicenow_rest/api.py
+++ b/servicenow_rest/api.py
@@ -34,6 +34,9 @@ class Client(object):
         ## Request properties
         self.table = None
 
+        ## Return properties
+        self.return_code = None
+
     def _create_session(self):
         """
         Creates and returns a new session object with the user/pw combination passed to the constructor
@@ -74,6 +77,7 @@ class Client(object):
         if 'error' in result:
             raise UnexpectedResponse("ServiceNow responded (%i): %s" % (request.status_code, result['error']['message']))
         else:
+            self.return_code = request.status_code
             return result['result']
 
     def _format_query(self, query={}, query_on={}):

--- a/servicenow_rest/api.py
+++ b/servicenow_rest/api.py
@@ -120,9 +120,9 @@ class Client(object):
             url = self.url
 
         if method == 'GET':
-            if type(query) is dict:
+            if isinstance(query, dict):
                 query = self._format_query(query)
-            elif type(query) is not str:
+            elif not isinstance(query, str):
                 raise InvalidUsage("You must pass a query using either a dictionary or string (for advanced queries)")
 
             request = self._session.get(

--- a/servicenow_rest/api.py
+++ b/servicenow_rest/api.py
@@ -116,9 +116,14 @@ class Client(object):
             url = self.url
 
         if method == 'GET':
+            if type(query) is dict:
+                query = self._format_query(query)
+            elif type(query) is not str:
+                raise InvalidUsage("You must pass a query using either a dictionary or string (for advanced queries)")
+
             request = self._session.get(
                 url,
-                params={'sysparm_query': self._format_query(query)}
+                params={'sysparm_query': query}
             )
         elif method == 'POST':
             request = self._session.post(


### PR DESCRIPTION
Hey Robert,

Hope you don't mind but I made a couple of small changes that I think could be quite useful, to at least myself but, hopefully anyone else using your library - which is really good by the way!!!

I've added the ability to pass a string to get() so you can pass an encoded query directly rather than building it using _format_query (i.e. s.get('nameINincident,task^elementLIKEstate') ) instead of just a plain a=1 type dict.

While I was at it I also removed the self.sys_id and added a return_code variable (as I figure this could be used if a non-200 was passed for some reason that didn't return an error like you're already checking for). Not sure if the latter is useful but I'll leave that for you to decide.

Also, was wondering what your intentions are for the query_on argument for _format_query function? You check for it but it is never actually passable so never gets used? I've never actually seen the ON feature of SN so not sure what you were trying to do here?

Look forward to your feedback :)

Allan