### PR TITLE
Config it to be able to use the attachment REST API

### DIFF
--- a/servicenow_rest/api.py
+++ b/servicenow_rest/api.py
@@ -21,7 +21,7 @@ class InvalidUsage(Exception):
 
 
 class Client(object):
-    base = "api/now/table"
+    base = "api/now"
 
     def __init__(self, instance, user, password, raise_on_empty=True):
         ## Connection properties
@@ -50,6 +50,10 @@ class Client(object):
 
     @property
     def url(self):
+
+        if self.table != 'attachment':
+            self.table = "/%s/%s" % ("table", self.table)
+
         url_str = 'https://%(fqdn)s/%(base)s/%(table)s' % (
             {
                 'fqdn': self.fqdn,


### PR DESCRIPTION
ServiceNow namespace is not that good and attachment REST API doesn't have the same path as other tables.

Incident: /api/now/table/incident
Attachment: /api/now/attachment

Thanks!